### PR TITLE
Suppression des espaces dans les hashtags

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -69,7 +69,7 @@ class Helper
                     $meta = App::meta()->getMetaRecordset($rs->post_meta, 'tag');
                     $meta->sort('meta_id_lower', 'asc');
                     while ($meta->fetch()) {
-                        $tags[] = '#' . $meta->meta_id;
+                        $tags[] = '#' . str_replace(' ', '', $meta->meta_id);
                     }
                     $elements[] = implode(' ', $tags);
                 }


### PR DESCRIPTION
Lorsqu'on active la publication des mots-clés, on conserve les espaces des mots-clés définis pour le billet. Ils ne sont donc pas correctement renseignés lors de la publication sur Mastodon.

Dans mon cas, on passe par exemple de : #Reseaux sociaux
À : #Reseauxsociaux