### PR TITLE
Amélioration affichage

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -72,10 +72,10 @@ class Helper
                     while ($meta->fetch()) {
                         $tags[] = '#' . self::convertTag($meta->meta_id, $mode);
                     }
-                    $elements[] = implode(' ', $tags);
+                    $elements[] = "\n" . implode(' ', array_slice($tags, 1));
                 }
                 // URL
-                $elements[] = $rs->getURL();
+                $elements[] = "\n" . $rs->getURL();
 
                 $payload = [
                     'status'     => implode(' ', $elements),


### PR DESCRIPTION
Pour rendre les posts plus lisibles, je propose de mettre un retour à la ligne après préfixe + titre, supprimer le premier espace dans la liste de tags, et un nouveau retour à la ligne juste avant l'url.

Qu'en penses-tu ?